### PR TITLE
Add SM 1.11 compat for LoadFromAddress

### DIFF
--- a/memory.inc
+++ b/memory.inc
@@ -30,7 +30,7 @@ stock int LoadStringFromAddress(Address addr, char[] buffer, int maxlen,
 	int c;
 	char ch;
 	do {
-		ch = LoadFromAddress(addr + view_as<Address>(c), NumberType_Int8);
+		ch = view_as<int>(LoadFromAddress(addr + view_as<Address>(c), NumberType_Int8));
 		buffer[c] = ch;
 	} while (ch && ++c < maxlen - 1);
 	return c;


### PR DESCRIPTION
SM1.11 changes the return value from `LoadFromAddress` to `any` which for some reason causes the compiler to flip out. Gotta love them SourcePawn chars.