### PR TITLE
Add stock to calculate FOV dot product result

### DIFF
--- a/math.inc
+++ b/math.inc
@@ -137,7 +137,7 @@ stock void GetCenterFromPoints(const float pt1[3], const float pt2[3], float cen
 
 /**
  * Calculates the width of the forward view cone as a dot product result from the given angle.
- * This manually calculates the value of CBaseCombatCharacter's `m_flFieldOfView` data propety.
+ * This manually calculates the value of CBaseCombatCharacter's `m_flFieldOfView` data property.
  *
  * For reference: https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/npc_bullseye.cpp#L151
  *

--- a/math.inc
+++ b/math.inc
@@ -134,3 +134,16 @@ stock void GetCenterFromPoints(const float pt1[3], const float pt2[3], float cen
 	center[1] = pt1[1] + pt2[1] / 2.0;
 	center[2] = pt1[2] + pt2[2] / 2.0;
 }
+
+/**
+ * Calculates the width of the forward view cone as a dot product result from the given angle.
+ * This manually calculates the value of CBaseCombatCharacter's `m_flFieldOfView` data propety.
+ *
+ * For reference: https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/npc_bullseye.cpp#L151
+ *
+ * @param angle     The FOV value in degree
+ * @return          Width of the forward view cone as a dot product result
+ */
+stock float GetFOVDotProduct(float angle) {
+	return Cosine(DegToRad(angle) / 2.0);
+}

--- a/sdkports/vector.inc
+++ b/sdkports/vector.inc
@@ -18,7 +18,7 @@
  * @param flCosHalfFOV		The width of the forward view cone as a dot product result. For
  * 							subclasses of CBaseCombatCharacter, you can use the
  * 							`m_flFieldOfView` data property.  To manually calculate for a
- * 							desired FOV, use `cos(0.5 * FOV)`.
+ * 							desired FOV, use `GetFOVDotProduct(angle)` from math.inc.
  * @return					True if the point is within view from the source position at the
  * 							specified FOV.
  */


### PR DESCRIPTION
## Description

Adds a new stock to **math.inc** to manually calculate the value of CBaseCombatCharacter's `m_flFieldOfView` data property from the given FOV value.

While I was using **PointWithinViewAngle**, I noticed that the manually calculated value via the method from the function's comment didn't match with known values from the SDK.

I found how valve calculates it in [npc_bullseye's source code.](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/npc_bullseye.cpp#L151)

## Test

[To give npc_helicopter 360 degrees of vision, valve set the value of `m_flFieldOfView` to -1.](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/npc_attackchopper.cpp#L1084)

```sourcepawn
#include <sourcemod>
#include <stocksoup/math>

public void OnPluginStart()
{
	PrintToServer("FOV (360) Old = %f", Cosine(0.5 * 360.0));
	PrintToServer("FOV (360) New = %f", GetFOVDotProduct(360.0));
}
```

## Output

```
FOV (360) Old = -0.598460
FOV (360) New = -1.000000
```

