### PR TITLE
Added function to unlock convar and fixed unused variable warning

### DIFF
--- a/convars.inc
+++ b/convars.inc
@@ -25,6 +25,10 @@ stock void LockConVar(ConVar convar) {
 	convar.AddChangeHook(__stocksoup_LockConVar);
 }
 
+stock void UnlockConVar(ConVar convar) {
+	convar.RemoveChangeHook(__stocksoup_LockConVar);
+}
+
 static stock void __stocksoup_LockConVar(ConVar convar, const char[] oldValue,
 		const char[] newValue) {
 	char defaultValue[64];

--- a/math.inc
+++ b/math.inc
@@ -29,7 +29,7 @@ stock float LerpFloat(float flPercent, float a, float b) {
  * @param d        Output bound value corresponding to `b`.
  * @param clamp    If set, the returned value is clamped to be between `c` and `d`.
  */
-float RemapValueFloatEx(float i, float a, float b, float c, float d, bool clamp = false) {
+stock float RemapValueFloatEx(float i, float a, float b, float c, float d, bool clamp = false) {
 	if (a == b) {
 		return i > b ? d : c;
 	}

--- a/string.inc
+++ b/string.inc
@@ -286,6 +286,8 @@ stock int StringToFloatArray(const char[] str, float[] arr, int length, int &byt
  */
 stock int StringToIntArray(const char[] str, int[] arr, int length, int &bytesread = 0,
 		int nBase = 10) {
+	#pragma unused length
+	
 	int n, c;
 	for (int i, res; (i = StringToIntEx(str[c], res, nBase)); c += i) {
 		arr[n++] = res;


### PR DESCRIPTION
### Changes:

- Added function to unlock convar (aka allow its value to be changed)
- Fixed unused symbol compiler warning in string.inc:
```
\stocksoup\string.inc(287) : warning 203: symbol is never used: "length"
   287 | stock int StringToIntArray(const char[] str, int[] arr, int length, int &bytesread = 0,
---------------------------------------------------------------^
```

_Accidentally trimmed all trailing whitespace upon saving the file, but hopefully that's not a problem._